### PR TITLE
Memory Post Api Endpoints

### DIFF
--- a/app/backend/hiStoryBackend/api/helpers/custom_helpers.py
+++ b/app/backend/hiStoryBackend/api/helpers/custom_helpers.py
@@ -1,11 +1,60 @@
+from django.contrib.auth.models import AnonymousUser
+from rest_framework.permissions import BasePermission
+from rest_framework.exceptions import ValidationError
+from rest_framework.views import exception_handler
+
+
 def errors_from_dict_to_arr(errors_dict):
-    """
-    :param errors_dict: {'key1': ['error1', 'error2', ...], 'key2': ['error1', ...], ...}
-    :return: ['key1: error1', 'key1: error2', 'key1: error3', 'key2: error1', ... ]
-    """
-    non_field_errors_arr = errors_dict.pop('non_field_errors', [])
+	"""
+	:param errors_dict: {'key1': ['error1', 'error2', ...], 'key2': ['error1', ...], ...}
+	:return: ['key1: error1', 'key1: error2', 'key1: error3', 'key2: error1', ... ]
+	"""
+	non_field_errors_arr = errors_dict.pop('non_field_errors', [])
 
-    result = [f"{key}: {msg}" for key in errors_dict for msg in errors_dict[key]]
-    result.extend([msg for msg in non_field_errors_arr])
+	result = [f"{key}: {msg}" for key in errors_dict for msg in errors_dict[key]]
+	result.extend([msg for msg in non_field_errors_arr])
 
-    return result
+	return result
+
+
+def custom_exception_handler(exc, context):
+	"""
+	Custom exception handler for Django Rest Framework
+	"""
+	# Call RestFramework's default exception handler first,
+	# to get the standard error response.
+	response = exception_handler(exc, context)
+
+	if not response:
+		return None
+
+	if isinstance(exc, ValidationError):
+		errors_arr = errors_from_dict_to_arr(response.data)
+		response.data = {'errors': errors_arr}
+
+	else:
+		response.data['errors'] = [response.data.pop('detail')]
+
+	return response
+
+
+class IsOwnerOrAdmin(BasePermission):
+	"""
+	Object-level permission to only allow owners of an object to edit it and
+	owners and admins to delete it.
+	Assumes the model instance has an `user` attribute.
+	"""
+
+	def has_object_permission(self, request, view, obj):
+		if request.method == 'GET':
+			if isinstance(request.user, AnonymousUser):
+				return False  # Guests cannot see a specific MemoryPost
+			return True
+
+		elif request.method in ('PUT', 'PATCH'):
+			return obj.user == request.user
+
+		elif request.method == 'DELETE':
+			return (obj.user == request.user) or request.user.admin
+		else:
+			return False

--- a/app/backend/hiStoryBackend/api/serializers.py
+++ b/app/backend/hiStoryBackend/api/serializers.py
@@ -8,71 +8,73 @@ from rest_framework import serializers
 from api.helpers.custom_helpers import errors_from_dict_to_arr
 
 
-class CustomBaseSerializer(serializers.ModelSerializer):
-    @property
-    def errors_arr(self):
-        return errors_from_dict_to_arr(self.errors)
+class CustomBaseModelSerializer(serializers.ModelSerializer):
+	@property
+	def errors_arr(self):
+		return errors_from_dict_to_arr(self.errors)
 
 
-class UserSerializer(CustomBaseSerializer):
-    password_confirmation = serializers.CharField(max_length=255, write_only=True)
+class UserSerializer(CustomBaseModelSerializer):
+	password_confirmation = serializers.CharField(max_length=255, write_only=True)
 
-    class Meta:
-        model = User
-        fields = ('username', 'email', 'first_name', 'last_name', 'admin', 'confirmed', 'banned',
-                  'password', 'password_confirmation')
-        extra_kwargs = {'password': {'write_only': True}}
+	class Meta:
+		model = User
+		fields = ('username', 'email', 'first_name', 'last_name', 'admin', 'confirmed', 'banned',
+				  'password', 'password_confirmation')
+		extra_kwargs = {'password': {'write_only': True}}
 
-    def validate(self, data):
-        password = data.get('password', None)
-        if password:
-            if len(password) < 8:
-                raise serializers.ValidationError("Password must be at least 8 characters long.")
+	def validate(self, data):
+		password = data.get('password', None)
+		if password:
+			if len(password) < 8:
+				raise serializers.ValidationError("Password must be at least 8 characters long.")
 
-            if password != data.get('password_confirmation', None):
-                raise serializers.ValidationError("'password' does not match 'password_confirmation'")
+			if password != data.get('password_confirmation', None):
+				raise serializers.ValidationError("'password' does not match 'password_confirmation'")
 
-        return data
+		return data
 
-    def create(self, validated_data):
-        user = User(username=validated_data['username'],
-                    email=validated_data['email'],
-                    first_name=validated_data.get('first_name', ''),
-                    last_name=validated_data.get('last_name', '')
-                    )
-        user.set_password(validated_data['password'])
-        user.save()
+	def create(self, validated_data):
+		user = User(username=validated_data['username'],
+					email=validated_data['email'],
+					first_name=validated_data.get('first_name', ''),
+					last_name=validated_data.get('last_name', '')
+					)
+		user.set_password(validated_data['password'])
+		user.save()
 
-        return user
+		return user
 
-    def update(self, instance, validated_data):
-        instance.username = validated_data.get('username', instance.username)
-        instance.email = validated_data.get('email', instance.email)
-        instance.first_name = validated_data.get('first_name', instance.first_name)
-        instance.last_name = validated_data.get('last_name', instance.last_name)
+	def update(self, instance, validated_data):
+		instance.username = validated_data.get('username', instance.username)
+		instance.email = validated_data.get('email', instance.email)
+		instance.first_name = validated_data.get('first_name', instance.first_name)
+		instance.last_name = validated_data.get('last_name', instance.last_name)
 
-        password = validated_data.get('password', None)
-        if password:
-            instance.set_password(password)
-            instance.password_reset_token = None
+		password = validated_data.get('password', None)
+		if password:
+			instance.set_password(password)
+			instance.password_reset_token = None
 
-        instance.save()
+		instance.save()
 
-        return instance
+		return instance
 
 
-class MemoryPostSerializer(CustomBaseSerializer):
-	story = serializers.JSONField(required = False)
-	location = serializers.JSONField(required = False)
-	time = serializers.JSONField(required = False)
+class MemoryPostSerializer(CustomBaseModelSerializer):
+	story_arr = serializers.ListField(write_only=True)
+
+	story = serializers.JSONField(read_only=True, required=False)
+	location = serializers.JSONField(required=False)
+	time = serializers.JSONField(required=False)
 	username = serializers.SerializerMethodField()
-	
-	def get_username(self, obj):
-		return obj.user.username
 
 	class Meta:
 		model = MemoryPost
 		exclude = ('user',)
+
+	def get_username(self, obj):
+		return obj.user.username
 
 	def validate_json_array(self, field_name, field_value):
 		if isinstance(field_value, str):
@@ -93,26 +95,43 @@ class MemoryPostSerializer(CustomBaseSerializer):
 	def validate_location(self, value):
 		return self.validate_json_array('location', value)
 
-	def create(self, validated_data):
-		memory_post = MemoryPost(	user = validated_data['user'],
-									title = validated_data['title'],
-									time = validated_data.get('time'),
-									location = validated_data.get('location'))
-		memory_post.save()
+	def create_memory_post_story(self, memory_post, story_arr):
 		story = []
-		for i, item in enumerate(validated_data['story']):
+		for i, item in enumerate(story_arr):
 			if isinstance(item, File):
-				if not item.content_type.startswith('image') and not item.content_type.startswith('video') and not item.content_type.startswith('audio'):
+				if not item.content_type.split('/')[0] in ('audio', 'image', 'video'):
 					continue
-				memory_media = MemoryMedia(	memory_post = memory_post,
-											type = item.content_type,
-											order = i,
-											file = item)
+
+				memory_media = MemoryMedia(memory_post=memory_post,
+										   type=item.content_type,
+										   order=i,
+										   file=item)
 				memory_media.save()
 				story.append({"type": item.content_type, "payload": memory_media.file.url})
-			else:
+			elif isinstance(item, str):
 				story.append({"type": "text", "payload": item})
-		memory_post.story = story
-		
+
+		return story
+
+	def create(self, validated_data):
+		memory_post = MemoryPost(user=validated_data['user'],
+								 title=validated_data['title'],
+								 time=validated_data.get('time'),
+								 location=validated_data.get('location')
+								 )
 		memory_post.save()
+		memory_post.story = self.create_memory_post_story(memory_post, validated_data['story_arr'])
+		memory_post.save()
+
 		return memory_post
+
+	def update(self, instance, validated_data):
+		instance.memorymedia_set.all().delete()  # First, delete all old MemoryMedia items
+
+		instance.title = validated_data.get('title')
+		instance.time = validated_data.get('time')
+		instance.location = validated_data.get('location')
+		instance.story = self.create_memory_post_story(instance, validated_data['story_arr'])
+		instance.save()
+
+		return instance

--- a/app/backend/hiStoryBackend/api/urls.py
+++ b/app/backend/hiStoryBackend/api/urls.py
@@ -1,14 +1,16 @@
 from django.conf.urls import url
+
 from .views.v1.auth_views import SignUpView, SignInView, SignOutView, EmailConfirmationView, PasswordResetView
 from .views.v1.memory_post_views import MemoryPostView
 
 app_name = 'api'
 
 urlpatterns = [
-    url(r'^v1/signup/?$', SignUpView.as_view()),
-    url(r'^v1/signin/?$', SignInView.as_view()),
-    url(r'^v1/signout/?$', SignOutView.as_view()),
-    url(r'^v1/email_confirmation/?$', EmailConfirmationView.as_view()),
-    url(r'^v1/password_reset/?$', PasswordResetView.as_view()),
-    url(r'^v1/memory_posts/?$', MemoryPostView.as_view())
+	url(r'^v1/signup/?$', SignUpView.as_view()),
+	url(r'^v1/signin/?$', SignInView.as_view()),
+	url(r'^v1/signout/?$', SignOutView.as_view()),
+	url(r'^v1/email_confirmation/?$', EmailConfirmationView.as_view()),
+	url(r'^v1/password_reset/?$', PasswordResetView.as_view()),
+
+	url(r'^v1/memory_posts/?(/(?P<id>\d+)/?)?$', MemoryPostView.as_view())
 ]

--- a/app/backend/hiStoryBackend/api/views/v1/memory_post_views.py
+++ b/app/backend/hiStoryBackend/api/views/v1/memory_post_views.py
@@ -1,14 +1,57 @@
-from rest_framework.views import APIView
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import generics, mixins
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 from api.helpers import json_response_helpers as jrh
+from api.helpers.custom_helpers import IsOwnerOrAdmin
+from api.models import MemoryPost
 from api.serializers import MemoryPostSerializer
 
-class MemoryPostView(APIView):
 
-	def post(self, request, format = None):
-		memory_post_serializer = MemoryPostSerializer(data = request.data)
+class MemoryPostPageNumberPagination(PageNumberPagination):
+	page_size = 10
+
+
+class MemoryPostView(mixins.ListModelMixin,
+					 mixins.RetrieveModelMixin,
+					 mixins.UpdateModelMixin,
+					 mixins.DestroyModelMixin,
+					 generics.GenericAPIView):
+
+	permission_classes = (IsAuthenticatedOrReadOnly, IsOwnerOrAdmin)
+	queryset = MemoryPost.objects.all()
+	serializer_class = MemoryPostSerializer
+	lookup_field = 'id'
+	pagination_class = MemoryPostPageNumberPagination
+
+	def get(self, request, *args, **kwargs):
+		if kwargs.get("id"):
+			return self.retrieve(request, *args, **kwargs)  # Comes from RetrieveModelMixin
+		else:
+			queryset = self.get_queryset().order_by('id').reverse()
+			if isinstance(request.user, AnonymousUser):
+				queryset = queryset[:10]  # Guests can see last 10 MemoryPosts
+
+			self.queryset = queryset
+			return self.list(request, *args, **kwargs)  # Comes from ListModelMixin
+
+	def post(self, request, *args, **kwargs):
+		memory_post_serializer = self.get_serializer(data=request.data)
 		if memory_post_serializer.is_valid():
-			memory_post_serializer.save(user = request.user, story = request.data.getlist('story[]', []))
+			memory_post_serializer.save(user=request.user)
 			return jrh.success(memory_post_serializer.data)
 		else:
 			return jrh.fail(memory_post_serializer.errors_arr)
+
+	def put(self, request, *args, **kwargs):
+		if not kwargs.get("id"):
+			return jrh.fail(["'id' URL parameter is missing."])
+
+		return self.update(request, *args, **kwargs)  # Comes from UpdateModelMixin
+
+	def delete(self, request, *args, **kwargs):
+		if not kwargs.get("id"):
+			return jrh.fail(["'id' URL parameter is missing."])
+
+		return self.destroy(request, *args, **kwargs)  # Comes from DestroyModelMixin

--- a/app/backend/hiStoryBackend/api/views/v1/memory_post_views.py
+++ b/app/backend/hiStoryBackend/api/views/v1/memory_post_views.py
@@ -1,5 +1,8 @@
+import re
+
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import generics, mixins
+from rest_framework.generics import get_object_or_404
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
@@ -15,7 +18,6 @@ class MemoryPostPageNumberPagination(PageNumberPagination):
 
 class MemoryPostView(mixins.ListModelMixin,
 					 mixins.RetrieveModelMixin,
-					 mixins.UpdateModelMixin,
 					 mixins.DestroyModelMixin,
 					 generics.GenericAPIView):
 
@@ -24,6 +26,23 @@ class MemoryPostView(mixins.ListModelMixin,
 	serializer_class = MemoryPostSerializer
 	lookup_field = 'id'
 	pagination_class = MemoryPostPageNumberPagination
+
+	def parse_request_data(self, request_data):
+		story_pattern = re.compile(r"^story\[\d+\]$")  # Matches 'story[<digit>]'
+		story_keys = [key for key in request_data.keys() if story_pattern.match(key)]
+		if len(story_keys) == 0:
+			story_arr = None
+		else:
+			story_keys.sort()
+			story_arr = [request_data[key] for key in story_keys]
+
+		data = {'title': request_data.get('title'),
+				'time': request_data.get('time'),
+				'location': request_data.get('location'),
+				'story_arr': story_arr
+				}
+
+		return data
 
 	def get(self, request, *args, **kwargs):
 		if kwargs.get("id"):
@@ -37,7 +56,7 @@ class MemoryPostView(mixins.ListModelMixin,
 			return self.list(request, *args, **kwargs)  # Comes from ListModelMixin
 
 	def post(self, request, *args, **kwargs):
-		memory_post_serializer = self.get_serializer(data=request.data)
+		memory_post_serializer = self.get_serializer(data=self.parse_request_data(request.data))
 		if memory_post_serializer.is_valid():
 			memory_post_serializer.save(user=request.user)
 			return jrh.success(memory_post_serializer.data)
@@ -45,10 +64,19 @@ class MemoryPostView(mixins.ListModelMixin,
 			return jrh.fail(memory_post_serializer.errors_arr)
 
 	def put(self, request, *args, **kwargs):
-		if not kwargs.get("id"):
+		id_param = kwargs.get("id")
+		if not id_param:
 			return jrh.fail(["'id' URL parameter is missing."])
 
-		return self.update(request, *args, **kwargs)  # Comes from UpdateModelMixin
+		memory_post = get_object_or_404(MemoryPost, pk=id_param)
+		self.check_object_permissions(request, memory_post)
+
+		memory_post_serializer = self.get_serializer(memory_post, data=self.parse_request_data(request.data))
+		if memory_post_serializer.is_valid():
+			memory_post_serializer.save()
+			return jrh.success(memory_post_serializer.data)
+		else:
+			return jrh.fail(memory_post_serializer.errors_arr)
 
 	def delete(self, request, *args, **kwargs):
 		if not kwargs.get("id"):

--- a/app/backend/hiStoryBackend/hiStoryBackend/settings.py
+++ b/app/backend/hiStoryBackend/hiStoryBackend/settings.py
@@ -18,24 +18,26 @@ DEBUG = bool(os.environ.get('DJANGO_DEBUG', True))
 ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'api.apps.ApiConfig',
-    'rest_framework',
-    'rest_framework.authtoken',
+	'django.contrib.admin',
+	'django.contrib.auth',
+	'django.contrib.contenttypes',
+	'django.contrib.sessions',
+	'django.contrib.messages',
+	'django.contrib.staticfiles',
+	'api.apps.ApiConfig',
+	'rest_framework',
+	'rest_framework.authtoken',
 ]
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.TokenAuthentication',
-    ),
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated',
-    )
+	'DEFAULT_AUTHENTICATION_CLASSES': (
+		'rest_framework.authentication.TokenAuthentication',
+	),
+	'DEFAULT_PERMISSION_CLASSES': (
+		'rest_framework.permissions.IsAuthenticated',
+	),
+	'EXCEPTION_HANDLER': 'api.helpers.custom_helpers.custom_exception_handler',
+	'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
 }
 
 # GMAIL CREDENTIALS
@@ -47,68 +49,68 @@ FRONTEND_CONFIRMATION_BASE_URL = os.environ.get('DJANGO_FRONTEND_CONFIRMATION_BA
 FRONTEND_PASSWORD_RESET_BASE_URL = os.environ.get('DJANGO_FRONTEND_PASSWORD_RESET_BASE_URL')
 
 if GMAIL_USERNAME and GMAIL_PASSWORD:
-    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-    EMAIL_HOST = 'smtp.gmail.com'
-    EMAIL_PORT = 587
-    EMAIL_HOST_USER = GMAIL_USERNAME
-    EMAIL_HOST_PASSWORD = GMAIL_PASSWORD
-    EMAIL_USE_TLS = True
+	EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+	EMAIL_HOST = 'smtp.gmail.com'
+	EMAIL_PORT = 587
+	EMAIL_HOST_USER = GMAIL_USERNAME
+	EMAIL_HOST_PASSWORD = GMAIL_PASSWORD
+	EMAIL_USE_TLS = True
 else:
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+	EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    # 'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+	'django.middleware.security.SecurityMiddleware',
+	'django.contrib.sessions.middleware.SessionMiddleware',
+	'django.middleware.common.CommonMiddleware',
+	# 'django.middleware.csrf.CsrfViewMiddleware',
+	'django.contrib.auth.middleware.AuthenticationMiddleware',
+	'django.contrib.messages.middleware.MessageMiddleware',
+	'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
 ROOT_URLCONF = 'hiStoryBackend.urls'
 
 TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-            ],
-        },
-    },
+	{
+		'BACKEND': 'django.template.backends.django.DjangoTemplates',
+		'DIRS': [],
+		'APP_DIRS': True,
+		'OPTIONS': {
+			'context_processors': [
+				'django.template.context_processors.debug',
+				'django.template.context_processors.request',
+				'django.contrib.auth.context_processors.auth',
+				'django.contrib.messages.context_processors.messages',
+			],
+		},
+	},
 ]
 
 WSGI_APPLICATION = 'hiStoryBackend.wsgi.application'
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
+	'default': {
+		'ENGINE': 'django.db.backends.sqlite3',
+		'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+	}
 }
 DATABASES['default'].update(dj_database_url.config(conn_max_age=500))
 
 # Password validation
 # https://docs.djangoproject.com/en/2.1/ref/settings/#auth-password-validators
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
+	{
+		'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+	},
+	{
+		'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+	},
+	{
+		'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+	},
+	{
+		'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+	},
 ]
 
 # Internationalization
@@ -145,8 +147,8 @@ AWS_S3_SECRET_ACCESS_KEY = os.environ.get('DJANGO_AWS_S3_SECRET_ACCESS_KEY')
 AWS_STORAGE_BUCKET_NAME = os.environ.get('DJANGO_AWS_STORAGE_BUCKET_NAME')
 
 if AWS_S3_ACCESS_KEY_ID and AWS_S3_SECRET_ACCESS_KEY and AWS_STORAGE_BUCKET_NAME:
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-    AWS_QUERYSTRING_AUTH = False  # Don't add complex authentication-related query parameters for requests
+	DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+	AWS_QUERYSTRING_AUTH = False  # Don't add complex authentication-related query parameters for requests
 
 
 django_heroku.settings(locals())

--- a/app/backend/hiStoryBackend/hiStoryBackend/settings.py
+++ b/app/backend/hiStoryBackend/hiStoryBackend/settings.py
@@ -38,6 +38,7 @@ REST_FRAMEWORK = {
 	),
 	'EXCEPTION_HANDLER': 'api.helpers.custom_helpers.custom_exception_handler',
 	'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+	'DATETIME_FORMAT': '%d-%m-%Y %H:%M:%S',
 }
 
 # GMAIL CREDENTIALS


### PR DESCRIPTION
Hello,

This PR contains the implementations for those endpoints:

```
GET api/v1/memory_posts/<id>
```
If `<id>` is provided, gets details of that `MemoryPost`;
Else, gets all the `MemoryPost`s (sorted from newest to oldest, 10 items per request/page)
NOTE: Guests can only get last 10 `MemoryPost`s


```
PUT api/v1/memory_posts/<id>
```
Replaces the `MemoryPost` with given `<id>` with a new one built from the provided (form) data. (See the note for 'POST' below)


```
DELETE api/v1/memory_posts/<id>
```
Deletes the `MemoryPost` with given `<id>`.
NOTE: Admins can delete any `MemoryPost`s.


### Note for `POST api/v1/memory_posts`:
The items for the `story` part of the `MemoryPost` should be provided with `story[<index>]` keys:
```
'story[0]': 'some text',
'story[1]': <ImageFile>,
'story[2]': <AudioFile>,
'story[3]': 'another text',
'story[4]': <VideoFile>,
...
```