### PR TITLE
Replace PUT /api/v1/memory_posts/<id> with PATCH for Partial Update

### DIFF
--- a/app/backend/hiStoryBackend/api/serializers.py
+++ b/app/backend/hiStoryBackend/api/serializers.py
@@ -123,12 +123,15 @@ class MemoryPostSerializer(CustomBaseModelSerializer):
 		return memory_post
 
 	def update(self, instance, validated_data):
-		instance.memorymedia_set.all().delete()  # First, delete all old MemoryMedia items
+		instance.title = validated_data.get('title', instance.title)
+		instance.time = validated_data.get('time', instance.time)
+		instance.location = validated_data.get('location', instance.location)
 
-		instance.title = validated_data.get('title')
-		instance.time = validated_data.get('time')
-		instance.location = validated_data.get('location')
-		instance.story = self.create_memory_post_story(instance, validated_data['story_arr'])
+		story_arr = validated_data.get('story_arr')
+		if story_arr:
+			instance.memorymedia_set.all().delete()  # Delete all the old MemoryMedia items
+			instance.story = self.create_memory_post_story(instance, story_arr)
+
 		instance.save()
 
 		return instance

--- a/app/backend/hiStoryBackend/api/views/v1/memory_post_views.py
+++ b/app/backend/hiStoryBackend/api/views/v1/memory_post_views.py
@@ -71,7 +71,7 @@ class MemoryPostView(mixins.ListModelMixin,
 		else:
 			return jrh.fail(memory_post_serializer.errors_arr)
 
-	def put(self, request, *args, **kwargs):
+	def patch(self, request, *args, **kwargs):
 		id_param = kwargs.get("id")
 		if not id_param:
 			return jrh.fail(["'id' URL parameter is missing."])
@@ -79,7 +79,7 @@ class MemoryPostView(mixins.ListModelMixin,
 		memory_post = get_object_or_404(MemoryPost, pk=id_param)
 		self.check_object_permissions(request, memory_post)
 
-		memory_post_serializer = self.get_serializer(memory_post, data=self.parse_request_data(request.data))
+		memory_post_serializer = self.get_serializer(memory_post, data=self.parse_request_data(request.data), partial=True)
 		if memory_post_serializer.is_valid():
 			memory_post_serializer.save()
 			return jrh.success(memory_post_serializer.data)


### PR DESCRIPTION
Hello all,

As you know, our API endpoint for updating a Memory-Post is `PUT .../memory_posts/<id>` which in fact replaces the Memory-Post with given `<id>` completely with the one built from the request parameters.

This PR contains changes that add the support for partial update. Now, for example, to update only the Memory-Title, clients can make a request to `PATCH .../memory_posts/<id>` with only the `title` parameter.

Note the change of the HTTP method from `PUT` to `PATCH`. `PATCH` is the preferred method for partial updates as long as I know.