### PR TITLE
Backend python-dotenv Integration

### DIFF
--- a/app/backend/hiStoryBackend/.gitignore
+++ b/app/backend/hiStoryBackend/.gitignore
@@ -18,3 +18,4 @@ staticfiles/
 # CMake
 cmake-build-*/
 
+*.env

--- a/app/backend/hiStoryBackend/hiStoryBackend/settings.py
+++ b/app/backend/hiStoryBackend/hiStoryBackend/settings.py
@@ -2,6 +2,9 @@ import os
 
 import dj_database_url
 import django_heroku
+from dotenv import load_dotenv
+
+load_dotenv()  # Loads environment variables from `.env` file if it exists
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/app/backend/hiStoryBackend/requirements.txt
+++ b/app/backend/hiStoryBackend/requirements.txt
@@ -17,6 +17,7 @@ Pillow==5.3.0
 psycopg2==2.7.5
 psycopg2-binary==2.7.5
 python-dateutil==2.7.4
+python-dotenv==0.10.1
 pytz==2018.5
 requests==2.21.0
 s3transfer==0.1.13

--- a/app/backend/readme.md
+++ b/app/backend/readme.md
@@ -1,1 +1,4 @@
-Backend
+## HiStory Backend
+
+* `hiStoryBackend`: Main `Django` project that serves as the backend. (See the `README` of this directory for details.)
+* `tag_similarity`: A helper CPP program for the **Recommendation** system.


### PR DESCRIPTION
Hello,

This PR contains the integration of [python-dotenv](https://github.com/theskumar/python-dotenv) package. This allows the `Django` to read environment varibles from a file named `.env`. We will provide a `.env` file which contains the environment variables currently used in production server when we deliver the product to the customers.